### PR TITLE
Fixes #9

### DIFF
--- a/newrelic/go-agent.v3/context.go
+++ b/newrelic/go-agent.v3/context.go
@@ -11,7 +11,9 @@ const NewRelicTransaction = "__newrelic_transaction__"
 func FromContext(ctx context.Context) *newrelic.Transaction {
 	txn := newrelic.FromContext(ctx)
 	if txn == nil {
-		return ctx.Value(NewRelicTransaction).(*newrelic.Transaction)
+		if txn, ok := ctx.Value(NewRelicTransaction).(*newrelic.Transaction); ok {
+			return txn
+		}
 	}
 	return txn
 }


### PR DESCRIPTION
This PR prevents the application from panicking if for some reason the request context does not have a transaction in it as described in #9 

I had this issue due to some wrong configs and I think the best behaviour, resiliency-wise, is to return an empty reference to the transaction and just warn from the agent [like this](https://github.com/americanas-go/ignite/blob/main/go-resty/resty.v2/plugins/contrib/newrelic/go-agent.v3/register.go#L30).
