### PR TITLE
feature: add resty.NewClient constructor

### DIFF
--- a/go-resty/resty.v2/client.go
+++ b/go-resty/resty.v2/client.go
@@ -11,6 +11,14 @@ import (
 
 type Plugin func(context.Context, *resty.Client) error
 
+func NewClient(ctx context.Context, plugins ...Plugin) (*resty.Client, error) {
+	opts, err := NewOptions()
+	if err != nil {
+		return nil, err
+	}
+	return NewClientWithOptions(ctx, opts, plugins...), nil
+}
+
 func NewClientWithOptions(ctx context.Context, options *Options, plugins ...Plugin) *resty.Client {
 
 	logger := log.FromContext(ctx)


### PR DESCRIPTION
This PR adds a `NewClient` constructor for the resty `Client` following the convention throughout all the other clients.