### PR TITLE
Feature/v1.0.0 beta.1

### DIFF
--- a/aws/aws-sdk-go.v2/client/sqs/client.go
+++ b/aws/aws-sdk-go.v2/client/sqs/client.go
@@ -6,21 +6,29 @@ import (
 	"github.com/americanas-go/errors"
 	"github.com/americanas-go/log"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 // Client knows how to publish on sqs
 type Client interface {
 	Publish(ctx context.Context, input *sqs.SendMessageInput) error
+	ResolveQueueUrl(ctx context.Context, queueName string) (*string, error)
+}
+
+type sqsClient interface {
+	SendMessage(ctx context.Context, params *sqs.SendMessageInput, optFns ...func(*sqs.Options)) (*sqs.SendMessageOutput, error)
+	GetQueueUrl(ctx context.Context, params *sqs.GetQueueUrlInput, optFns ...func(*sqs.Options)) (*sqs.GetQueueUrlOutput, error)
 }
 
 // Client holds client and resource name
 type client struct {
-	client *sqs.Client
+	client    sqsClient
+	queueUrls map[string]*string
 }
 
 // NewClient returns a initialized client
 func NewClient(c *sqs.Client) Client {
-	return &client{c}
+	return &client{c, map[string]*string{}}
 }
 
 // Publish publish message on sns
@@ -42,4 +50,26 @@ func (c *client) Publish(ctx context.Context, input *sqs.SendMessageInput) error
 		Debug("message sent to sqs")
 
 	return nil
+}
+
+func (c *client) ResolveQueueUrl(ctx context.Context, queueName string) (*string, error) {
+	if queueUrl, ok := c.queueUrls[queueName]; ok {
+		return queueUrl, nil
+	}
+
+	result, err := c.client.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{
+		QueueName: aws.String(queueName),
+	})
+
+	if err != nil {
+		return nil, errors.Wrap(err, errors.New("error resolving sqs queue url"))
+	}
+
+	if result == nil || result.QueueUrl == nil {
+		return nil, errors.New("error resolving sqs queue url")
+	}
+
+	c.queueUrls[queueName] = result.QueueUrl
+
+	return result.QueueUrl, nil
 }

--- a/aws/aws-sdk-go.v2/client/sqs/client.go
+++ b/aws/aws-sdk-go.v2/client/sqs/client.go
@@ -66,7 +66,7 @@ func (c *client) ResolveQueueUrl(ctx context.Context, queueName string) (*string
 	}
 
 	if result == nil || result.QueueUrl == nil {
-		return nil, errors.New("error resolving sqs queue url")
+		return nil, errors.Errorf("sqs queue %s not found", queueName)
 	}
 
 	c.queueUrls[queueName] = result.QueueUrl

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/americanas-go/multiserver v1.1.0
 	github.com/americanas-go/rest-response v1.0.2
 	github.com/ansrivas/fiberprometheus/v2 v2.1.2
+	github.com/aws/aws-sdk-go v1.36.1
 	github.com/aws/aws-sdk-go-v2 v1.6.0
 	github.com/aws/aws-sdk-go-v2/config v1.3.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.2.1


### PR DESCRIPTION
Please check the code and versioning above... I got this solution for get the sqs queue url, but the point is: the message is build outside of the library, so i decided to expose this method, in order to allowing set the QueueUrl on the message created instead of letting the method Publish set it. The problem with the later approach is that you should inform the queue name  every time you call the method and i think it would be better set everything required on message, before calling Publish method. For the enduser this will be transparent. Please let me know if something is bad smelling