### PR TITLE
Allow using go-redis datadog plugin without americanas-go/config setup

### DIFF
--- a/go-redis/redis.v8/plugins/contrib/datadog/dd-trace-go.v1/client_datadog.go
+++ b/go-redis/redis.v8/plugins/contrib/datadog/dd-trace-go.v1/client_datadog.go
@@ -18,6 +18,11 @@ func NewClientDatadogWithConfigPath(path string, traceOptions ...redistrace.Clie
 	if err != nil {
 		return nil, err
 	}
+
+	if !datadog.IsTracerEnabled() {
+		o.Enabled = false
+	}
+
 	return NewClientDatadogWithOptions(o), nil
 }
 
@@ -35,8 +40,7 @@ func NewClientDatadogWithOptions(options *Options) *ClientDatadog {
 }
 
 func (d *ClientDatadog) Register(ctx context.Context, client *redis.Client) error {
-
-	if !d.options.Enabled || !datadog.IsTracerEnabled() {
+	if !d.options.Enabled {
 		return nil
 	}
 

--- a/go-redis/redis.v8/plugins/contrib/datadog/dd-trace-go.v1/cluster_datadog.go
+++ b/go-redis/redis.v8/plugins/contrib/datadog/dd-trace-go.v1/cluster_datadog.go
@@ -2,8 +2,8 @@ package datadog
 
 import (
 	"context"
-
 	datadog "github.com/americanas-go/ignite/datadog/dd-trace-go.v1"
+
 	"github.com/americanas-go/log"
 	"github.com/go-redis/redis/v8"
 	redistrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis.v8"
@@ -18,6 +18,11 @@ func NewClusterDatadogWithConfigPath(path string, traceOptions ...redistrace.Cli
 	if err != nil {
 		return nil, err
 	}
+
+	if !datadog.IsTracerEnabled() {
+		o.Enabled = false
+	}
+	
 	return NewClusterDatadogWithOptions(o), nil
 }
 
@@ -35,8 +40,7 @@ func NewClusterDatadogWithOptions(options *Options) *ClusterDatadog {
 }
 
 func (d *ClusterDatadog) Register(ctx context.Context, client *redis.ClusterClient) error {
-
-	if !d.options.Enabled || !datadog.IsTracerEnabled() {
+	if !d.options.Enabled {
 		return nil
 	}
 


### PR DESCRIPTION
Datadog's plugin `Register` function used `IsTraceEnabled` which depends on `americanas-go/config`. 

Since we don't use `americanas-go/config` this would stop us from using the datadog plugin.

This PR moves this logic to the `New*DatadogWithConfigPath` functions, which are designed to be coupled to the `americanas-go/config` setup, reflecting the value of `IsTraceEnabled` on the plugins options, making it the single source of truth for the operational code path.

Avoiding hard dependencies to `americanas-go/config` is paramount to keep ignite a true loosely coupled set of helpers. 
