### PR TITLE
hotfix: update otelresty version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.14.0
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be
 	github.com/coocood/freecache v1.2.3
-	github.com/dubonzi/otelresty v1.1.1
+	github.com/dubonzi/otelresty v1.1.2
 	github.com/elastic/go-elasticsearch/v7 v7.17.10
 	github.com/elastic/go-elasticsearch/v8 v8.8.2
 	github.com/globocom/echo-prometheus v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -1181,8 +1181,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/dubonzi/otelresty v1.1.1 h1:i9Eb9O67um3xigfJBEGPE2VRK6XZ2D/eNlOjz0UL4wI=
-github.com/dubonzi/otelresty v1.1.1/go.mod h1:VUlW9GU0o2uwOd52An0YobsJDXfjAZul/5GgRx+Gcyw=
+github.com/dubonzi/otelresty v1.1.2 h1:bA/s2FdnEWjwMMt0D50hqZ7uCH/Ff6Dwg/X4Cw5epYg=
+github.com/dubonzi/otelresty v1.1.2/go.mod h1:VUlW9GU0o2uwOd52An0YobsJDXfjAZul/5GgRx+Gcyw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
Updating `otelresty` version to fix a problem when marking spans as error. (see https://github.com/dubonzi/otelresty/commit/6865d20f283e2b068e9c0403c45abb4473af2ff9)

